### PR TITLE
JD-540: fix checkstyle checking generated sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <packaging>pom</packaging>
   <groupId>com.rbkmoney</groupId>
   <artifactId>service-parent-pom</artifactId>
-  <version>2.0.7</version>
+  <version>2.0.8</version>
   <description>RBKmoney spring starter parent</description>
   <name>RBKmoney spring starter parent</name>
   <url>https://github.com/rbkmoney/service-parent-pom</url>
@@ -273,6 +273,9 @@
                   <failsOnError>true</failsOnError>
                   <consoleOutput>true</consoleOutput>
                   <violationSeverity>warning</violationSeverity>
+                  <sourceDirectories>
+                    <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                  </sourceDirectories>
                   <includeTestSourceDirectory>true</includeTestSourceDirectory>
                   <suppressionsLocation>${checkstyle.config.suppressions.path}</suppressionsLocation>
                 </configuration>


### PR DESCRIPTION
Шаг с `mvn install` был добавлен в [build_utils](https://github.com/rbkmoney/build_utils/pull/100/files).
В ходе исполнения checkstyle проверяет сгенерированные классы jooq и проваливаются сборки, например:

- [magista](http://ci.rbkmoney.com/job/rbkmoney_private/job/magista/job/PR-336/1/)
- [adapter-crm-megaplan](http://ci.rbkmoney.com/job/rbkmoney_private/job/adapter-crm-megaplan/job/PR-70/9/)

В связи с этим жестко задал папку с исходниками для проверки.
